### PR TITLE
feat: allows src and code 

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "http-server": "^14.1.1",
     "https-browserify": "^1.0.0",
     "mini-css-extract-plugin": "^2.2.2",
+    "near-bos-webcomponent": "^0.0.2",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "postcss-loader": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "http-server": "^14.1.1",
     "https-browserify": "^1.0.0",
     "mini-css-extract-plugin": "^2.2.2",
-    "near-bos-webcomponent": "^0.0.2",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "postcss-loader": "^7.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -14,9 +14,10 @@ import {
 
 const SESSION_STORAGE_REDIRECT_MAP_KEY = 'nearSocialVMredirectMap';
 
-function Viewer() {
+function Viewer({ widgetSrc, code }) {
   const [widgetProps, setWidgetProps] = useState({});
   const location = useLocation();
+
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
     setWidgetProps(
@@ -27,7 +28,7 @@ function Viewer() {
     );
   }, [location]);
 
-  let src = location.pathname;
+  let src = widgetSrc || code || location.pathname;
   if (src) {
     src = src.substring(src.lastIndexOf('/', src.indexOf('.near')) + 1);
   } else {

--- a/src/App.js
+++ b/src/App.js
@@ -6,11 +6,14 @@ import "react-bootstrap-typeahead/css/Typeahead.bs5.css";
 import "bootstrap/dist/js/bootstrap.bundle";
 import "App.scss";
 
-import { BrowserRouter as Router, Link, Route, useLocation } from "react-router-dom";
-import { sanitizeUrl } from "@braintree/sanitize-url";
 import {
-  useInitNear,
-} from "near-social-vm";
+  BrowserRouter as Router,
+  Link,
+  Route,
+  useLocation,
+} from "react-router-dom";
+import { sanitizeUrl } from "@braintree/sanitize-url";
+import { useInitNear } from "near-social-vm";
 
 const SESSION_STORAGE_REDIRECT_MAP_KEY = 'nearSocialVMredirectMap';
 
@@ -28,29 +31,43 @@ function Viewer({ widgetSrc, code }) {
     );
   }, [location]);
 
-  let src = widgetSrc || code || location.pathname;
-  if (src) {
-    src = src.substring(src.lastIndexOf('/', src.indexOf('.near')) + 1);
-  } else {
-    src = 'devhub.near/widget/app';
+  let src;
+
+  if (!code) { // prioritize code if provided
+    src = widgetSrc || location.pathname;
+    if (src) {
+      src = src.substring(src.lastIndexOf('/', src.indexOf('.near')) + 1);
+    } else {
+      src = 'devhub.near/widget/app';
+    }
   }
 
   const [redirectMap, setRedirectMap] = useState(null);
   useEffect(() => {
     (async () => {
-      const localStorageFlags = JSON.parse(localStorage.getItem('flags'));
+      const localStorageFlags = JSON.parse(localStorage.getItem("flags"));
 
       if (localStorageFlags?.bosLoaderUrl) {
         setRedirectMap(
-          (await fetch(localStorageFlags.bosLoaderUrl).then(r => r.json())).components
+          (await fetch(localStorageFlags.bosLoaderUrl).then((r) => r.json()))
+            .components
         );
       } else {
-        setRedirectMap(JSON.parse(sessionStorage.getItem(SESSION_STORAGE_REDIRECT_MAP_KEY)));
+        setRedirectMap(
+          JSON.parse(sessionStorage.getItem(SESSION_STORAGE_REDIRECT_MAP_KEY))
+        );
       }
     })();
   }, []);
 
-  return <Widget src={src} props={widgetProps} config={{ redirectMap }} />;
+  return (
+    <Widget
+      src={src}
+      code={code}
+      props={widgetProps}
+      config={{ redirectMap }}
+    />
+  );
 }
 
 function App(props) {
@@ -81,7 +98,7 @@ function App(props) {
   return (
     <Router>
       <Route>
-        <Viewer></Viewer>
+        <Viewer widgetSrc={props.widgetSrc} code={props.code}></Viewer>
       </Route>
     </Router>
   );

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,24 @@ class NearSocialViewerElement extends HTMLElement {
         const container = document.createElement('div');
         this.appendChild(container);
 
+        const src = this.getAttribute('src');
+        const code = this.getAttribute('code');
+
         const root = createRoot(container);
-        root.render(<App />);
+        root.render(<App widgetSrc={src} code={code} />);
+    }
+
+    static get observedAttributes() {
+        return ['src', 'code'];
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        // Re-render the component with new props when attributes change
+        if (oldValue !== newValue) {
+            const container = this.shadowRoot.querySelector('div');
+            const root = createRoot(container);
+            root.render(<App {...{[name]: newValue}} />);
+        }
     }
 }
 


### PR DESCRIPTION
Currently the web component takes the widget src from location.pathname.

The [NEARSocial/VM](https://github.com/NearSocial/VM) can take either [src or code](https://github.com/NearSocial/VM/blob/9fe2d4ec05727ee2e2db8ddf198556220a169a4f/src/lib/components/Widget.js#L88).

The goal of this PR is to allow the latter, where src or code can be passed from attributes